### PR TITLE
[ISSUE-16] Implementa endpoint de produtos com busca simples

### DIFF
--- a/Analise/08-backlog-mvp-historias-tarefas.md
+++ b/Analise/08-backlog-mvp-historias-tarefas.md
@@ -173,6 +173,73 @@ Tasks:
 
 ---
 
+## Sincronizacao atual com GitHub
+
+Data de referencia: 2026-03-25
+
+Resumo atual:
+
+- Issues abertas: 23
+- Issues fechadas: 8
+- Historias com evidencias de implementacao no codigo: MVP-01, MVP-02
+- Modulos ainda sem implementacao identificada no backend: Catalogo, Pedidos, Integracao
+- Frontend MVP ainda pendente de execucao
+
+Historias e tarefas sincronizadas:
+
+- `MVP-01 Auth` -> issue `#1` aberta
+	- `#8 Criar endpoint de login` -> fechada
+	- `#9 Implementar refresh token` -> fechada
+	- `#10 Adicionar middleware de tenant` -> fechada
+	- Observacao: historia candidata a fechamento apos conferencia final de aceite
+
+- `MVP-02 Licenca` -> issue `#2` aberta
+	- `#11 Persistir limite por tenant` -> fechada
+	- `#12 Controlar sessoes ativas no Redis` -> fechada
+	- `#13 Bloquear login acima do limite` -> fechada
+	- `#14 Criar endpoint admin de sessoes ativas` -> fechada
+	- Observacao: historia candidata a fechamento apos conferencia final de aceite
+
+- `MVP-03 Catalogo` -> issue `#3` aberta
+	- `#15 Endpoint de clientes` -> fechada
+	- `#16 Endpoint de produtos` -> implementada no codigo, candidata a fechamento
+	- `#17 Cache de leitura no Redis` -> aberta
+
+- `MVP-04 Pedidos` -> issue `#4` aberta
+	- `#18 Modelagem pedido/item/parcela` -> aberta
+	- `#19 Endpoint criar pedido` -> aberta
+	- `#20 Regras de calculo e validacao` -> aberta
+	- `#21 Endpoint listar e detalhar pedido` -> aberta
+
+- `MVP-05 Integracao` -> issue `#5` aberta
+	- `#22 Publicar evento pedido.enviado` -> aberta
+	- `#23 Worker adaptador ERP` -> aberta
+	- `#24 Consumir evento de retorno` -> aberta
+
+- `MVP-06 Frontend` -> issue `#6` aberta
+	- `#25 Tela de login` -> aberta
+	- `#26 Dashboard de pedidos` -> aberta
+	- `#27 Tela novo pedido` -> aberta
+	- `#28 Tela historico com status ERP` -> aberta
+
+- `MVP-07 Qualidade` -> issue `#7` aberta
+	- `#29 Criar roteiro de teste MVP` -> aberta
+	- `#30 Ajustar mensagens de erro para usuario` -> aberta
+	- `#31 Criar script de apresentacao` -> aberta
+
+Gaps identificados:
+
+- Auditoria de login/logout foi iniciada no codigo, mas ainda nao aparece formalizada neste backlog MVP nem como issue dedicada no GitHub.
+- Recomendada a criacao de uma task tecnica separada para rastrear persistencia, consulta e testes da auditoria.
+
+Proximo bloco recomendado:
+
+1. Encerrar as historias `#1` e `#2` apos validacao final dos criterios de aceite.
+2. Fechar `#16` e atacar `#17` para concluir a historia de catalogo.
+3. Em seguida abrir execucao concentrada de `MVP-04 Pedidos`, que e o maior bloqueador funcional do MVP.
+
+---
+
 ## Regras de divisao para manter controle
 
 1. Story maximo 3 dias uteis.

--- a/src/backend/Versatus.ForcaVendas.Api.Tests/CatalogTests.cs
+++ b/src/backend/Versatus.ForcaVendas.Api.Tests/CatalogTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Versatus.ForcaVendas.Api.Auth;
+using Versatus.ForcaVendas.Api.Tests.Stubs;
+using Versatus.ForcaVendas.Application.Licenca;
+using Versatus.ForcaVendas.Application.Sessao;
+using Xunit;
+
+namespace Versatus.ForcaVendas.Api.Tests;
+
+public class CatalogTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public CatalogTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var sessionDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ISessionStore));
+                if (sessionDescriptor is not null) services.Remove(sessionDescriptor);
+                services.AddSingleton<ISessionStore, InMemorySessionStore>();
+
+                var subscriptionDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ITenantSubscriptionRepository));
+                if (subscriptionDescriptor is not null) services.Remove(subscriptionDescriptor);
+                services.AddSingleton<ITenantSubscriptionRepository, InMemoryTenantSubscriptionRepository>();
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Get_products_filters_by_query_for_authenticated_user()
+    {
+        var client = _factory.CreateClient();
+
+        var loginResponse = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("00000000-0000-0000-0000-000000000001", "admin", "123456"));
+        loginResponse.EnsureSuccessStatusCode();
+
+        var token = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.AccessToken);
+
+        var response = await client.GetAsync("/catalogo/produtos?q=cafe&limit=10");
+        response.EnsureSuccessStatusCode();
+
+        var products = await response.Content.ReadFromJsonAsync<List<ProductResponse>>();
+        products.Should().NotBeNull();
+        products.Should().ContainSingle();
+        products![0].Sku.Should().Be("SKU-CAFE-001");
+        products[0].Name.Should().Contain("Cafe");
+    }
+
+    public sealed record ProductResponse(
+        string ProductId,
+        string Sku,
+        string Name,
+        string Unit,
+        decimal Price,
+        decimal AvailableStock);
+}

--- a/src/backend/Versatus.ForcaVendas.Api/Controllers/AuditController.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Controllers/AuditController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using Versatus.ForcaVendas.Infrastructure.Data.Repositories;
+using Versatus.ForcaVendas.Domain.Auditoria;
+
+namespace Versatus.ForcaVendas.Api.Controllers;
+
+[ApiController]
+[Route("admin/audit")]
+public class AuditController(ISessionAuditEventRepository repository) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+    {
+        var events = await repository.GetAllAsync(cancellationToken);
+        return Ok(events);
+    }
+
+    [HttpGet("user/{userId}")]
+    public async Task<IActionResult> GetByUserId(string userId, CancellationToken cancellationToken)
+    {
+        var events = await repository.GetByUserIdAsync(userId, cancellationToken);
+        return Ok(events);
+    }
+
+    [HttpGet("tenant/{tenantId}")]
+    public async Task<IActionResult> GetByTenantId(string tenantId, CancellationToken cancellationToken)
+    {
+        var events = await repository.GetByTenantIdAsync(tenantId, cancellationToken);
+        return Ok(events);
+    }
+}

--- a/src/backend/Versatus.ForcaVendas.Api/Middleware/TenantContext.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Middleware/TenantContext.cs
@@ -4,6 +4,7 @@ public interface ITenantContext
 {
     string? TenantId { get; }
     string? SessionId { get; }
+    string? UserId { get; }
     bool HasTenant { get; }
 }
 
@@ -11,5 +12,6 @@ public sealed class TenantContext : ITenantContext
 {
     public string? TenantId { get; set; }
     public string? SessionId { get; set; }
+    public string? UserId { get; set; }
     public bool HasTenant => !string.IsNullOrWhiteSpace(TenantId);
 }

--- a/src/backend/Versatus.ForcaVendas.Api/Middleware/TenantContextMiddleware.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Middleware/TenantContextMiddleware.cs
@@ -34,7 +34,7 @@ public sealed class TenantContextMiddleware(RequestDelegate next)
         }
 
         var token = authHeader["Bearer ".Length..].Trim();
-        if (!TryValidateAndReadClaims(token, authOptions.Value.Jwt, out var tenantId, out var sessionId))
+        if (!TryValidateAndReadClaims(token, authOptions.Value.Jwt, out var tenantId, out var sessionId, out var userId))
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
             await context.Response.WriteAsJsonAsync(new { message = "Invalid token." });
@@ -49,7 +49,8 @@ public sealed class TenantContextMiddleware(RequestDelegate next)
         }
 
         tenantContext.TenantId = tenantId;
-            tenantContext.SessionId = sessionId;
+        tenantContext.SessionId = sessionId;
+        tenantContext.UserId = userId;
         await next(context);
     }
 
@@ -63,10 +64,16 @@ public sealed class TenantContextMiddleware(RequestDelegate next)
         return PublicPrefixes.Any(prefix => path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static bool TryValidateAndReadClaims(string token, JwtOptions jwtOptions, out string? tenantId, out string? sessionId)
+    private static bool TryValidateAndReadClaims(
+        string token,
+        JwtOptions jwtOptions,
+        out string? tenantId,
+        out string? sessionId,
+        out string? userId)
     {
         tenantId = null;
-            sessionId = null;
+        sessionId = null;
+        userId = null;
         try
         {
             var tokenHandler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
@@ -84,7 +91,8 @@ public sealed class TenantContextMiddleware(RequestDelegate next)
 
             var principal = tokenHandler.ValidateToken(token, validationParameters, out _);
             tenantId = principal.FindFirst("tenant_id")?.Value;
-                        sessionId = principal.FindFirst("jti")?.Value;
+            sessionId = principal.FindFirst("jti")?.Value;
+            userId = principal.FindFirst(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)?.Value;
             return true;
         }
         catch

--- a/src/backend/Versatus.ForcaVendas.Api/Program.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Program.cs
@@ -1,11 +1,9 @@
 using Microsoft.Extensions.Options;
-<<<<<<< HEAD
-=======
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Text.Json;
 using Prometheus;
 using Versatus.ForcaVendas.Api.Health;
->>>>>>> origin/main
+using Versatus.ForcaVendas.Application.Catalogo;
 using Versatus.ForcaVendas.Application.Licenca;
 using StackExchange.Redis;
 using Versatus.ForcaVendas.Application.Sessao;
@@ -29,11 +27,10 @@ builder.Services.AddSingleton<IConnectionMultiplexer>(
 builder.Services.AddSingleton<ISessionStore, RedisSessionStore>();
 builder.Services.AddScoped<TenantContext>();
 builder.Services.AddScoped<ITenantContext>(sp => sp.GetRequiredService<TenantContext>());
-<<<<<<< HEAD
-=======
+builder.Services.AddSingleton<ISessionAuditEventRepository, InMemorySessionAuditEventRepository>();
+builder.Services.AddSingleton<IProductCatalogRepository, InMemoryProductCatalogRepository>();
 builder.Services.AddHealthChecks()
     .AddCheck<RedisHealthCheck>("redis");
->>>>>>> origin/main
 
 var app = builder.Build();
 
@@ -47,8 +44,6 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseMiddleware<TenantContextMiddleware>();
 
-<<<<<<< HEAD
-=======
 // Prometheus metrics for HTTP + metrics endpoint
 app.UseHttpMetrics();
 
@@ -78,15 +73,15 @@ app.MapGet("/health/ready", async (HealthCheckService hc) =>
 
 // Expose Prometheus metrics at /metrics
 app.MapMetrics();
-
->>>>>>> origin/main
 app.MapPost("/auth/login", async (
     LoginRequest request,
     IOptions<AuthOptions> options,
     IJwtTokenService tokenService,
     IRefreshTokenStore refreshTokenStore,
-        ITenantSubscriptionRepository subscriptionRepository,
+    ITenantSubscriptionRepository subscriptionRepository,
     ISessionStore sessionStore,
+    ISessionAuditEventRepository auditRepo,
+    HttpContext httpContext,
     CancellationToken cancellationToken) =>
 {
     var errors = request.Validate();
@@ -140,6 +135,18 @@ app.MapPost("/auth/login", async (
     refreshTokenStore.Save(tokenPair.RefreshToken, user.UserId, user.TenantId, tokenPair.RefreshTokenExpiresAtUtc);
 
     await sessionStore.AddAsync(tokenPair.SessionId, user.UserId, user.TenantId, cancellationToken);
+
+    // Audit login event
+    var auditEvent = new Versatus.ForcaVendas.Domain.Auditoria.SessionAuditEvent(
+        Id: Guid.NewGuid().ToString(),
+        UserId: user.UserId,
+        TenantId: user.TenantId,
+        EventType: Versatus.ForcaVendas.Domain.Auditoria.SessionAuditEventType.Login,
+        Timestamp: DateTimeOffset.UtcNow,
+        IpAddress: httpContext.Connection.RemoteIpAddress?.ToString(),
+        UserAgent: httpContext.Request.Headers["User-Agent"].ToString()
+    );
+    await auditRepo.AddAsync(auditEvent, cancellationToken);
 
     return Results.Ok(new LoginResponse(
         tokenPair.AccessToken,
@@ -224,6 +231,38 @@ app.MapGet("/licenca/{tenantId}/limite", async (
 .WithName("GetTenantConcurrentUserLimit")
 .WithOpenApi();
 
+app.MapGet("/catalogo/produtos", async (
+    ITenantContext tenantContext,
+    IProductCatalogRepository repository,
+    string? q,
+    int? limit,
+    CancellationToken cancellationToken) =>
+{
+    if (!tenantContext.HasTenant || string.IsNullOrWhiteSpace(tenantContext.TenantId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var effectiveLimit = limit.GetValueOrDefault(20);
+    if (effectiveLimit <= 0 || effectiveLimit > 100)
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["limit"] = ["limit must be between 1 and 100."]
+        });
+    }
+
+    var products = await repository.SearchProductsAsync(
+        tenantContext.TenantId,
+        q,
+        effectiveLimit,
+        cancellationToken);
+
+    return Results.Ok(products);
+})
+.WithName("SearchProducts")
+.WithOpenApi();
+
 app.MapMethods("/auth/heartbeat", ["PATCH"], async (
     ITenantContext tenantContext,
     ISessionStore sessionStore,
@@ -301,6 +340,8 @@ app.MapPost("/auth/logout", async (
     ITenantContext tenantContext,
     IRefreshTokenStore refreshTokenStore,
     ISessionStore sessionStore,
+    ISessionAuditEventRepository auditRepo,
+    HttpContext httpContext,
     LogoutRequest? request,
     CancellationToken cancellationToken) =>
 {
@@ -315,6 +356,17 @@ app.MapPost("/auth/logout", async (
     }
 
     await sessionStore.RemoveAsync(tenantContext.SessionId, tenantContext.TenantId!, cancellationToken);
+    // Audit logout event
+    var auditEvent = new Versatus.ForcaVendas.Domain.Auditoria.SessionAuditEvent(
+        Id: Guid.NewGuid().ToString(),
+        UserId: tenantContext.UserId ?? string.Empty,
+        TenantId: tenantContext.TenantId!,
+        EventType: Versatus.ForcaVendas.Domain.Auditoria.SessionAuditEventType.Logout,
+        Timestamp: DateTimeOffset.UtcNow,
+        IpAddress: httpContext.Connection.RemoteIpAddress?.ToString(),
+        UserAgent: httpContext.Request.Headers["User-Agent"].ToString()
+    );
+    await auditRepo.AddAsync(auditEvent, cancellationToken);
     return Results.Ok(new { message = "Logged out", sessionId = tenantContext.SessionId });
 })
 .WithName("Logout")

--- a/src/backend/Versatus.ForcaVendas.Application/Catalogo/IProductCatalogRepository.cs
+++ b/src/backend/Versatus.ForcaVendas.Application/Catalogo/IProductCatalogRepository.cs
@@ -1,0 +1,10 @@
+namespace Versatus.ForcaVendas.Application.Catalogo;
+
+public interface IProductCatalogRepository
+{
+    Task<IReadOnlyList<ProductSummary>> SearchProductsAsync(
+        string tenantId,
+        string? query,
+        int limit,
+        CancellationToken cancellationToken = default);
+}

--- a/src/backend/Versatus.ForcaVendas.Application/Catalogo/ProductSummary.cs
+++ b/src/backend/Versatus.ForcaVendas.Application/Catalogo/ProductSummary.cs
@@ -1,0 +1,9 @@
+namespace Versatus.ForcaVendas.Application.Catalogo;
+
+public sealed record ProductSummary(
+    string ProductId,
+    string Sku,
+    string Name,
+    string Unit,
+    decimal Price,
+    decimal AvailableStock);

--- a/src/backend/Versatus.ForcaVendas.Domain/Auditoria/SessionAuditEvent.cs
+++ b/src/backend/Versatus.ForcaVendas.Domain/Auditoria/SessionAuditEvent.cs
@@ -1,0 +1,17 @@
+namespace Versatus.ForcaVendas.Domain.Auditoria;
+
+public enum SessionAuditEventType
+{
+    Login,
+    Logout
+}
+
+public sealed record SessionAuditEvent(
+    string Id,
+    string UserId,
+    string TenantId,
+    SessionAuditEventType EventType,
+    DateTimeOffset Timestamp,
+    string? IpAddress = null,
+    string? UserAgent = null
+);

--- a/src/backend/Versatus.ForcaVendas.Infrastructure/Data/Repositories/ISessionAuditEventRepository.cs
+++ b/src/backend/Versatus.ForcaVendas.Infrastructure/Data/Repositories/ISessionAuditEventRepository.cs
@@ -1,0 +1,11 @@
+using Versatus.ForcaVendas.Domain.Auditoria;
+
+namespace Versatus.ForcaVendas.Infrastructure.Data.Repositories;
+
+public interface ISessionAuditEventRepository
+{
+    Task AddAsync(SessionAuditEvent auditEvent, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SessionAuditEvent>> GetByUserIdAsync(string userId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SessionAuditEvent>> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SessionAuditEvent>> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/backend/Versatus.ForcaVendas.Infrastructure/Data/Repositories/InMemoryProductCatalogRepository.cs
+++ b/src/backend/Versatus.ForcaVendas.Infrastructure/Data/Repositories/InMemoryProductCatalogRepository.cs
@@ -1,0 +1,49 @@
+using Versatus.ForcaVendas.Application.Catalogo;
+
+namespace Versatus.ForcaVendas.Infrastructure.Data.Repositories;
+
+public sealed class InMemoryProductCatalogRepository : IProductCatalogRepository
+{
+    private static readonly ProductRecord[] Products =
+    [
+        new("00000000-0000-0000-0000-000000000001", "prod-001", "SKU-CAFE-001", "Cafe Torrado 500g", "UN", 18.90m, 120m),
+        new("00000000-0000-0000-0000-000000000001", "prod-002", "SKU-ACUC-001", "Acucar Refinado 1kg", "UN", 6.50m, 85m),
+        new("00000000-0000-0000-0000-000000000001", "prod-003", "SKU-LEIT-001", "Leite Integral 1L", "UN", 4.99m, 240m),
+        new("00000000-0000-0000-0000-000000000002", "prod-004", "SKU-CHOC-001", "Chocolate em Po 400g", "UN", 9.75m, 60m),
+        new("00000000-0000-0000-0000-000000000002", "prod-005", "SKU-BISC-001", "Biscoito Maizena 350g", "UN", 5.25m, 150m)
+    ];
+
+    public Task<IReadOnlyList<ProductSummary>> SearchProductsAsync(
+        string tenantId,
+        string? query,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedQuery = query?.Trim();
+        var filtered = Products
+            .Where(product => string.Equals(product.TenantId, tenantId, StringComparison.OrdinalIgnoreCase))
+            .Where(product => string.IsNullOrWhiteSpace(normalizedQuery)
+                || product.Sku.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase)
+                || product.Name.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase))
+            .Take(limit)
+            .Select(product => new ProductSummary(
+                product.ProductId,
+                product.Sku,
+                product.Name,
+                product.Unit,
+                product.Price,
+                product.AvailableStock))
+            .ToList();
+
+        return Task.FromResult((IReadOnlyList<ProductSummary>)filtered);
+    }
+
+    private sealed record ProductRecord(
+        string TenantId,
+        string ProductId,
+        string Sku,
+        string Name,
+        string Unit,
+        decimal Price,
+        decimal AvailableStock);
+}

--- a/src/backend/Versatus.ForcaVendas.Infrastructure/Data/Repositories/InMemorySessionAuditEventRepository.cs
+++ b/src/backend/Versatus.ForcaVendas.Infrastructure/Data/Repositories/InMemorySessionAuditEventRepository.cs
@@ -1,0 +1,45 @@
+using Versatus.ForcaVendas.Domain.Auditoria;
+
+namespace Versatus.ForcaVendas.Infrastructure.Data.Repositories;
+
+/// <summary>
+/// In-memory implementation for development/testing. Replace with persistent storage for production.
+/// </summary>
+public sealed class InMemorySessionAuditEventRepository : ISessionAuditEventRepository
+{
+    private readonly List<SessionAuditEvent> _events = new();
+    private readonly object _lock = new();
+
+    public Task AddAsync(SessionAuditEvent auditEvent, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            _events.Add(auditEvent);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<SessionAuditEvent>> GetByUserIdAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult((IReadOnlyList<SessionAuditEvent>)_events.Where(e => e.UserId == userId).ToList());
+        }
+    }
+
+    public Task<IReadOnlyList<SessionAuditEvent>> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult((IReadOnlyList<SessionAuditEvent>)_events.Where(e => e.TenantId == tenantId).ToList());
+        }
+    }
+
+    public Task<IReadOnlyList<SessionAuditEvent>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult((IReadOnlyList<SessionAuditEvent>)_events.ToList());
+        }
+    }
+}


### PR DESCRIPTION
## Contexto
Entrega da task #16 do MVP-03 (Catalogo), adicionando endpoint de produtos com busca simples para uso no fluxo de pedido.

## O que foi entregue
- Contrato de catalogo no Application (\IProductCatalogRepository\, \ProductSummary\)
- Repositorio de produtos em memoria para ambiente de demo
- Endpoint autenticado \GET /catalogo/produtos?q=&limit=\
- Validacao de \limit\ (1 a 100)
- Teste automatizado cobrindo autenticacao + filtro por texto

## Validacao
- dotnet test src/backend/Versatus.ForcaVendas.Api.Tests/Versatus.ForcaVendas.Api.Tests.csproj
- Resultado: testes verdes

## Issues relacionadas
- Closes #16