### PR TITLE
[ISSUE-19] Cria endpoint POST /pedidos para rascunho

### DIFF
--- a/src/backend/Versatus.ForcaVendas.Api.Tests/PedidosTests.cs
+++ b/src/backend/Versatus.ForcaVendas.Api.Tests/PedidosTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Versatus.ForcaVendas.Api.Auth;
+using Versatus.ForcaVendas.Api.Pedidos;
+using Versatus.ForcaVendas.Api.Tests.Stubs;
+using Versatus.ForcaVendas.Application.Licenca;
+using Versatus.ForcaVendas.Application.Sessao;
+using Versatus.ForcaVendas.Infrastructure.Data;
+using Xunit;
+
+namespace Versatus.ForcaVendas.Api.Tests;
+
+public class PedidosTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PedidosTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var sessionDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ISessionStore));
+                if (sessionDescriptor is not null) services.Remove(sessionDescriptor);
+                services.AddSingleton<ISessionStore, InMemorySessionStore>();
+
+                var subscriptionDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ITenantSubscriptionRepository));
+                if (subscriptionDescriptor is not null) services.Remove(subscriptionDescriptor);
+                services.AddSingleton<ITenantSubscriptionRepository, InMemoryTenantSubscriptionRepository>();
+
+                var dbOptionsDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<PedidosDbContext>));
+                if (dbOptionsDescriptor is not null) services.Remove(dbOptionsDescriptor);
+
+                var dbContextDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(PedidosDbContext));
+                if (dbContextDescriptor is not null) services.Remove(dbContextDescriptor);
+
+                services.AddDbContext<PedidosDbContext>(options =>
+                    options.UseInMemoryDatabase($"pedidos-tests-{Guid.NewGuid()}"));
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_pedidos_creates_rascunho_with_itens_and_parcelas()
+    {
+        var client = _factory.CreateClient();
+
+        var loginResponse = await client.PostAsJsonAsync(
+            "/auth/login",
+            new LoginRequest("00000000-0000-0000-0000-000000000001", "admin", "123456"));
+        loginResponse.EnsureSuccessStatusCode();
+
+        var token = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.AccessToken);
+
+        var request = new CriarPedidoRequest(
+            ClienteId: "cli-001",
+            Itens:
+            [
+                new CriarPedidoItemRequest("prod-001", "SKU-001", "Produto 1", 2, 10m, 0m),
+                new CriarPedidoItemRequest("prod-002", "SKU-002", "Produto 2", 1, 5m, 0m)
+            ],
+            CondicaoPagamento: new CriarPedidoCondicaoPagamentoRequest(2, DateTime.UtcNow.Date.AddDays(7), "boleto"));
+
+        var response = await client.PostAsJsonAsync("/pedidos", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.ToString().Should().Contain("/pedidos/");
+
+        var body = await response.Content.ReadFromJsonAsync<CreatePedidoResponse>();
+        body.Should().NotBeNull();
+        body!.Status.Should().Be("rascunho");
+        body.ItensCount.Should().Be(2);
+        body.ParcelasCount.Should().Be(2);
+    }
+
+    private sealed record CreatePedidoResponse(string PedidoId, string Status, int ItensCount, int ParcelasCount);
+}

--- a/src/backend/Versatus.ForcaVendas.Api.Tests/Versatus.ForcaVendas.Api.Tests.csproj
+++ b/src/backend/Versatus.ForcaVendas.Api.Tests/Versatus.ForcaVendas.Api.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/src/backend/Versatus.ForcaVendas.Api/Pedidos/CriarPedidoCommand.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Pedidos/CriarPedidoCommand.cs
@@ -1,0 +1,106 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Versatus.ForcaVendas.Domain.Pedidos;
+using Versatus.ForcaVendas.Infrastructure.Data;
+
+namespace Versatus.ForcaVendas.Api.Pedidos;
+
+public sealed record CriarPedidoCommand(
+    string TenantId,
+    string ClienteId,
+    IReadOnlyList<CriarPedidoItemRequest> Itens,
+    CriarPedidoCondicaoPagamentoRequest CondicaoPagamento) : IRequest<CriarPedidoResult>;
+
+public sealed record CriarPedidoResult(Guid PedidoId, string Status, int ItensCount, int ParcelasCount);
+
+public sealed class CriarPedidoCommandHandler : IRequestHandler<CriarPedidoCommand, CriarPedidoResult>
+{
+    private readonly PedidosDbContext _dbContext;
+
+    public CriarPedidoCommandHandler(PedidosDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<CriarPedidoResult> Handle(CriarPedidoCommand request, CancellationToken cancellationToken)
+    {
+        var pedidoId = Guid.NewGuid();
+        var criadoEm = DateTimeOffset.UtcNow;
+
+        var itens = request.Itens.Select(item =>
+        {
+            var totalItem = Math.Round((item.Quantidade * item.PrecoUnitario) - item.Desconto, 2, MidpointRounding.AwayFromZero);
+            return new PedidoItem
+            {
+                Id = Guid.NewGuid(),
+                PedidoId = pedidoId,
+                ProdutoId = item.ProdutoId,
+                Sku = item.Sku,
+                Nome = item.Nome,
+                Quantidade = item.Quantidade,
+                PrecoUnitario = item.PrecoUnitario,
+                Desconto = item.Desconto,
+                Total = totalItem
+            };
+        }).ToList();
+
+        var totalPedido = itens.Sum(i => i.Total);
+        var parcelas = CriarParcelas(
+            pedidoId,
+            totalPedido,
+            request.CondicaoPagamento.QuantidadeParcelas,
+            request.CondicaoPagamento.PrimeiroVencimento,
+            request.CondicaoPagamento.FormaPagamento);
+
+        var pedido = new Pedido
+        {
+            Id = pedidoId,
+            TenantId = request.TenantId,
+            ClienteId = request.ClienteId,
+            CriadoEm = criadoEm,
+            StatusId = PedidoStatus.RascunhoId,
+            Itens = itens,
+            Parcelas = parcelas
+        };
+
+        _dbContext.Pedidos.Add(pedido);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var status = await _dbContext.PedidoStatuses
+            .Where(s => s.Id == PedidoStatus.RascunhoId)
+            .Select(s => s.Codigo)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return new CriarPedidoResult(pedido.Id, status ?? "rascunho", itens.Count, parcelas.Count);
+    }
+
+    private static List<PedidoParcela> CriarParcelas(
+        Guid pedidoId,
+        decimal valorTotal,
+        int quantidadeParcelas,
+        DateTime primeiroVencimento,
+        string formaPagamento)
+    {
+        var parcelas = new List<PedidoParcela>(quantidadeParcelas);
+        var valorBase = Math.Round(valorTotal / quantidadeParcelas, 2, MidpointRounding.AwayFromZero);
+
+        for (var i = 1; i <= quantidadeParcelas; i++)
+        {
+            var valor = i == quantidadeParcelas
+                ? Math.Round(valorTotal - (valorBase * (quantidadeParcelas - 1)), 2, MidpointRounding.AwayFromZero)
+                : valorBase;
+
+            parcelas.Add(new PedidoParcela
+            {
+                Id = Guid.NewGuid(),
+                PedidoId = pedidoId,
+                Numero = i,
+                DataVencimento = primeiroVencimento.Date.AddMonths(i - 1),
+                Valor = valor,
+                FormaPagamento = formaPagamento
+            });
+        }
+
+        return parcelas;
+    }
+}

--- a/src/backend/Versatus.ForcaVendas.Api/Pedidos/CriarPedidoRequest.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Pedidos/CriarPedidoRequest.cs
@@ -1,0 +1,90 @@
+namespace Versatus.ForcaVendas.Api.Pedidos;
+
+public sealed record CriarPedidoRequest(
+    string ClienteId,
+    IReadOnlyList<CriarPedidoItemRequest> Itens,
+    CriarPedidoCondicaoPagamentoRequest CondicaoPagamento)
+{
+    public Dictionary<string, string[]> Validate()
+    {
+        var errors = new Dictionary<string, string[]>();
+
+        if (string.IsNullOrWhiteSpace(ClienteId))
+        {
+            errors["clienteId"] = ["clienteId is required."];
+        }
+
+        if (Itens is null || Itens.Count == 0)
+        {
+            errors["itens"] = ["at least one item is required."];
+        }
+        else
+        {
+            for (var i = 0; i < Itens.Count; i++)
+            {
+                var item = Itens[i];
+                if (string.IsNullOrWhiteSpace(item.ProdutoId))
+                {
+                    errors[$"itens[{i}].produtoId"] = ["produtoId is required."];
+                }
+
+                if (string.IsNullOrWhiteSpace(item.Sku))
+                {
+                    errors[$"itens[{i}].sku"] = ["sku is required."];
+                }
+
+                if (string.IsNullOrWhiteSpace(item.Nome))
+                {
+                    errors[$"itens[{i}].nome"] = ["nome is required."];
+                }
+
+                if (item.Quantidade <= 0)
+                {
+                    errors[$"itens[{i}].quantidade"] = ["quantidade must be greater than zero."];
+                }
+
+                if (item.PrecoUnitario <= 0)
+                {
+                    errors[$"itens[{i}].precoUnitario"] = ["precoUnitario must be greater than zero."];
+                }
+            }
+        }
+
+        if (CondicaoPagamento is null)
+        {
+            errors["condicaoPagamento"] = ["condicaoPagamento is required."];
+        }
+        else
+        {
+            if (CondicaoPagamento.QuantidadeParcelas <= 0)
+            {
+                errors["condicaoPagamento.quantidadeParcelas"] = ["quantidadeParcelas must be greater than zero."];
+            }
+
+            if (CondicaoPagamento.PrimeiroVencimento == default)
+            {
+                errors["condicaoPagamento.primeiroVencimento"] = ["primeiroVencimento is required."];
+            }
+
+            if (string.IsNullOrWhiteSpace(CondicaoPagamento.FormaPagamento))
+            {
+                errors["condicaoPagamento.formaPagamento"] = ["formaPagamento is required."];
+            }
+        }
+
+        return errors;
+    }
+}
+
+public sealed record CriarPedidoItemRequest(
+    string ProdutoId,
+    string Sku,
+    string Nome,
+    decimal Quantidade,
+    decimal PrecoUnitario,
+    decimal Desconto);
+
+public sealed record CriarPedidoCondicaoPagamentoRequest(
+    int QuantidadeParcelas,
+    DateTime PrimeiroVencimento,
+    string FormaPagamento);

--- a/src/backend/Versatus.ForcaVendas.Api/Program.cs
+++ b/src/backend/Versatus.ForcaVendas.Api/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
+using MediatR;
 using Prometheus;
 using Versatus.ForcaVendas.Api.Health;
 using Versatus.ForcaVendas.Application.Catalogo;
@@ -9,6 +10,7 @@ using StackExchange.Redis;
 using Versatus.ForcaVendas.Application.Sessao;
 using Versatus.ForcaVendas.Api.Auth;
 using Versatus.ForcaVendas.Api.Middleware;
+using Versatus.ForcaVendas.Api.Pedidos;
 using Versatus.ForcaVendas.Infrastructure.Data;
 using Versatus.ForcaVendas.Infrastructure.Data.Repositories;
 
@@ -32,6 +34,7 @@ builder.Services.AddSingleton<ISessionAuditEventRepository, InMemorySessionAudit
 builder.Services.AddSingleton<IProductCatalogRepository, InMemoryProductCatalogRepository>();
 builder.Services.AddDbContext<PedidosDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddMediatR(typeof(CriarPedidoCommand));
 builder.Services.AddHealthChecks()
     .AddCheck<RedisHealthCheck>("redis");
 
@@ -264,6 +267,40 @@ app.MapGet("/catalogo/produtos", async (
     return Results.Ok(products);
 })
 .WithName("SearchProducts")
+.WithOpenApi();
+
+app.MapPost("/pedidos", async (
+    ITenantContext tenantContext,
+    CriarPedidoRequest request,
+    IMediator mediator,
+    CancellationToken cancellationToken) =>
+{
+    if (!tenantContext.HasTenant || string.IsNullOrWhiteSpace(tenantContext.TenantId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var errors = request.Validate();
+    if (errors.Count > 0)
+    {
+        return Results.ValidationProblem(errors);
+    }
+
+    var result = await mediator.Send(new CriarPedidoCommand(
+        tenantContext.TenantId,
+        request.ClienteId,
+        request.Itens,
+        request.CondicaoPagamento), cancellationToken);
+
+    return Results.Created($"/pedidos/{result.PedidoId}", new
+    {
+        pedidoId = result.PedidoId,
+        status = result.Status,
+        itensCount = result.ItensCount,
+        parcelasCount = result.ParcelasCount
+    });
+})
+.WithName("CreatePedido")
 .WithOpenApi();
 
 app.MapMethods("/auth/heartbeat", ["PATCH"], async (

--- a/src/backend/Versatus.ForcaVendas.Api/Versatus.ForcaVendas.Api.csproj
+++ b/src/backend/Versatus.ForcaVendas.Api/Versatus.ForcaVendas.Api.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="11.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.23" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">


### PR DESCRIPTION
## Contexto
Entrega da task #19 do MVP-04 (Pedidos), adicionando criação de pedido em status rascunho.

## O que foi entregue
- Command MediatR: CriarPedidoCommand
- Endpoint autenticado POST /pedidos
- Persistência de pedido, itens e parcelas via PedidosDbContext
- Response 201 Created com Location e payload com pedidoId + status ascunho
- Teste de integração cobrindo autenticação, criação e contrato de resposta

## Validacao
- dotnet test src/backend/Versatus.ForcaVendas.Api.Tests/Versatus.ForcaVendas.Api.Tests.csproj
- Resultado: 3 testes verdes

## Issues relacionadas
- Closes #19